### PR TITLE
fix for incorrect grid cell size, issue #5

### DIFF
--- a/src/umwm_init.F90
+++ b/src/umwm_init.F90
@@ -410,7 +410,7 @@ subroutine grid
 !======================================================================!
 use netcdf
 use umwm_io,  only:nc_check
-use umwm_util,only:raiseexception
+use umwm_util,only:raiseexception, distance_haversine
 !======================================================================!
 
 logical :: loniscontinuous = .true.
@@ -498,9 +498,10 @@ if(gridfromfile)then
 
   do n=1,nm
     do m=2,mm-1
-      dx_2d(m,n) = r_earth*2*asin(sqrt((sin(0.5*(rlat(m+1,n)-rlat(m-1,n))))**2&
-                                       +cos(rlat(m-1,n))*cos(rlat(m+1,n))&
-                                      *(sin(0.5*(rlon(m+1,n)-rlon(m-1,n))))**2))
+      dx_2d(m,n) = r_earth * distance_haversine(0.5*(rlon(m-1,n) + rlon(m  ,n)), &
+                                                0.5*(rlon(m  ,n) + rlon(m+1,n)), &
+                                                0.5*(rlat(m-1,n) + rlat(m  ,n)), &
+                                                0.5*(rlat(m  ,n) + rlat(m+1,n)))
     end do
   end do
 
@@ -509,9 +510,10 @@ if(gridfromfile)then
 
   do n=2,nm-1
     do m=1,mm
-      dy_2d(m,n) = r_earth*2*asin(sqrt((sin(0.5*(rlat(m,n+1)-rlat(m,n-1))))**2&
-                                       +cos(rlat(m,n-1))*cos(rlat(m,n+1))&
-                                      *(sin(0.5*(rlon(m,n+1)-rlon(m,n-1))))**2))
+      dy_2d(m,n) = r_earth * distance_haversine(0.5*(rlon(m,n-1) + rlon(m,n  )), &
+                                                0.5*(rlon(m,n  ) + rlon(m,n+1)), &
+                                                0.5*(rlat(m,n-1) + rlat(m,n  )), &
+                                                0.5*(rlat(m,n  ) + rlat(m,n+1)))
     end do
   end do
 

--- a/src/umwm_util.F90
+++ b/src/umwm_util.F90
@@ -204,4 +204,31 @@ deallocate(sbf,sdv,sdt,snl_arg,dummy,e,ef,rotl,rotr,sds,snl,ssin,sice)
 
 endsubroutine dealloc
 !======================================================================!
+
+
+
+pure function distance_haversine(lon1, lon2, lat1, lat2) result(distance)
+!======================================================================+
+!                                                                      !
+! calculates shortest distance between two points on the surface       !
+! of a sphere using the Haversine formula                              !                                 !
+!                                                                      !
+!======================================================================+
+    
+! arguments
+real :: distance
+real, intent(in) :: lon1, lon2, lat1, lat2
+
+! local
+real :: dlon, dlat
+
+dlon = abs(lon2 - lon1)
+dlat = abs(lat2 - lat1)
+
+distance = 2 * asin( sqrt( (sin(0.5 * dlat))**2 + &
+                     cos(lat1) * cos(lat2) * (sin(0.5 * dlon))**2 ) )
+
+end function distance_haversine
+!======================================================================>
+
 end module umwm_util


### PR DESCRIPTION
Addresses issue #5. Note that the dx_2d(:,:) and dy_2d(:,:) arrays contain the sizes of the grid cells, rather than the grid cell (center to center) distances.  